### PR TITLE
Add improvements from `work`

### DIFF
--- a/lazy-lock.json
+++ b/lazy-lock.json
@@ -51,6 +51,7 @@
   "schemastore.nvim": { "branch": "main", "commit": "48dba219db5d45baad6f7491e754706f74d12676" },
   "smart-splits.nvim": { "branch": "master", "commit": "ddb23c1a1cf1507bda487cda7f6e4690965ef9f5" },
   "snacks.nvim": { "branch": "main", "commit": "a4e46becca45eb65c73a388634b1ce8aad629ae0" },
+  "text-transform": { "branch": "master", "commit": "335b3ad36d8b276b7b56028108d32b1c91f26d76" },
   "todo-comments.nvim": { "branch": "main", "commit": "31e3c38ce9b29781e4422fc0322eb0a21f4e8668" },
   "toggleterm.nvim": { "branch": "main", "commit": "50ea089fc548917cc3cc16b46a8211833b9e3c7c" },
   "tsc.nvim": { "branch": "main", "commit": "e4773833726beec2e8a8e11f0b21613b5472b97b" },

--- a/lua/plugins/astrolsp.lua
+++ b/lua/plugins/astrolsp.lua
@@ -13,7 +13,20 @@ return {
             format = {
               enable = false,
             },
+            tsserver = {
+              maxTsServerMemory = 8192,
+              nodePath = "node",
+            },
           },
+        },
+      },
+    },
+    mappings = {
+      n = {
+        -- this mapping will only be set in buffers with an LSP attached
+        ["<Leader>lp"] = {
+          function() vim.cmd "LspRestart" end,
+          desc = "Restart LSP",
         },
       },
     },

--- a/lua/plugins/texttransform.lua
+++ b/lua/plugins/texttransform.lua
@@ -1,0 +1,41 @@
+return {
+  {
+    "chenasraf/text-transform.nvim",
+    name = "text-transform",
+    opts = {
+      --- Prints information about internals of the plugin. Very verbose, only useful for debugging.
+      debug = false,
+      --- Keymap configurations
+      keymap = {
+        --- Keymap to open the telescope popup. Set to `false` or `nil` to disable keymapping
+        --- You can always customize your own keymapping manually.
+        telescope_popup = {
+          --- Opens the popup in visual/visual block modes
+          ["v"] = "<Leader>~",
+        },
+      },
+      ---
+      --- Configurations for the text-transform replacers
+      --- Keys indicate the replacer name, and the value is a table with the following options:
+      ---
+      --- - `enabled` (boolean): Enable or disable the replacer - disabled replacers do not show up in the popup.
+      replacers = {
+        camel_case = { enabled = true },
+        const_case = { enabled = true },
+        dot_case = { enabled = true },
+        kebab_case = { enabled = true },
+        pascal_case = { enabled = true },
+        snake_case = { enabled = true },
+        title_case = { enabled = true },
+      },
+
+      --- Sort the replacers in the popup.
+      --- Possible values: 'frequency', 'name'
+      sort_by = "frequency",
+
+      --- The popup type to show.
+      --- Possible values: 'telescope', 'select'
+      popup_type = "select",
+    },
+  },
+}


### PR DESCRIPTION
A few improvements from the work config:

- Adds `text-transform` plugin (and config) for faster case transformations
- Adds handy mapping to restart LSP server (as opposed to typing `:LspRestart` manually every time)
- Increases max TS server memory to 8gb (for real this time as a `nodePath` is actually specified) 