### PR TITLE
Remove eslint LSP

### DIFF
--- a/lua/community.lua
+++ b/lua/community.lua
@@ -8,7 +8,7 @@ return {
   { import = "astrocommunity.colorscheme.dracula-nvim" },
   { import = "astrocommunity.pack.lua" },
   { import = "astrocommunity.pack.typescript" },
-  { import = "astrocommunity.pack.eslint" },
+  { import = "astrocommunity.pack.prettier" },
   { import = "astrocommunity.pack.tailwindcss" },
   { import = "astrocommunity.pack.html-css" },
   { import = "astrocommunity.pack.toml" },


### PR DESCRIPTION
- Linting is slow, but formatting is fast (see [these docs](https://typescript-eslint.io/users/what-about-formatting/#formatters-vs-linters) for a more in-depth explanation)
- The `ESLint` LSP insists on running after every keypress, despite my best efforts
	- I suspect this is related to [this open Neovim issue](https://github.com/neovim/neovim/issues/39785) where debouncing doesn't behave as expected
	- Once this is resolved, I should be able to set the `allow_incremental_sync` and `debounce_text_changes` flags [(reference)](https://neovim.io/doc/user/lsp/#_lua-module:-vim.lsp.client) to debounce the requests to the ESLint LSP. It sounds like [these flags used to work](https://github.com/neovim/nvim-lspconfig/issues/3211#issuecomment-2236416552), but have been broken in recent Nvim versions?
- In the mean time, I can still perform the fast step (formatting with prettier) on save by adding AstroCommunity's `prettier` package. I'll need to remember to manually run ESLint every so often (or just whenever CI/CD fails 🥴)