### PR TITLE
Add ts-expand-hover to work

### DIFF
--- a/lazy-lock.json
+++ b/lazy-lock.json
@@ -51,6 +51,7 @@
   "text-transform": { "branch": "master", "commit": "335b3ad36d8b276b7b56028108d32b1c91f26d76" },
   "todo-comments.nvim": { "branch": "main", "commit": "31e3c38ce9b29781e4422fc0322eb0a21f4e8668" },
   "toggleterm.nvim": { "branch": "main", "commit": "50ea089fc548917cc3cc16b46a8211833b9e3c7c" },
+  "ts-expand-hover.nvim": { "branch": "main", "commit": "f83350d29e7163ac2dc017900051565b41addd1f" },
   "tsc.nvim": { "branch": "main", "commit": "e083bcf1e54bc3af7df92b33235efb334e8c782c" },
   "which-key.nvim": { "branch": "main", "commit": "fcbf4eea17cb299c02557d576f0d568878e354a4" }
 }

--- a/lua/plugins/ts-expand-hover.lua
+++ b/lua/plugins/ts-expand-hover.lua
@@ -1,0 +1,12 @@
+return {
+  "nemanjamalesija/ts-expand-hover.nvim",
+  ft = { "typescript", "typescriptreact" },
+  opts = {
+    keymaps = {
+      -- Override default hover keymap
+      hover = "K",
+      -- No shift required to increase depth
+      expand = "=",
+    },
+  },
+}


### PR DESCRIPTION
Allows for expanding TypeScript definitions in the hover tooltip, could be useful

Notably does not have TSGO support, so I'll have to revisit this if/when we upgrade to it